### PR TITLE
Bugfix: Limit which branches triggers the CI workflow.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,9 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+      - 'feature/**'
+      - 'bugfix/**'
   pull_request:
 jobs:
   restore-build-test:


### PR DESCRIPTION
The CI workflow is only triggered when pushes are made to the main branch, as well as feature and bugfix branches.