### PR TITLE
Migrated CrawlCtrl.Reader to this repo.

### DIFF
--- a/CrawlCtrl.sln
+++ b/CrawlCtrl.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Extensions.Micros
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test", "test\CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test\CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test.csproj", "{C2AD4BB5-64AB-488B-B89D-2F85B41173FA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader", "src\CrawlCtrl.Reader\CrawlCtrl.Reader.csproj", "{8A72EACD-45F9-4AEA-8EFF-26C5B75398B9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader.UnitTests", "test\CrawlCtrl.Reader.UnitTests\CrawlCtrl.Reader.UnitTests.csproj", "{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +46,13 @@ Global
 		{C2AD4BB5-64AB-488B-B89D-2F85B41173FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2AD4BB5-64AB-488B-B89D-2F85B41173FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2AD4BB5-64AB-488B-B89D-2F85B41173FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A72EACD-45F9-4AEA-8EFF-26C5B75398B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A72EACD-45F9-4AEA-8EFF-26C5B75398B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A72EACD-45F9-4AEA-8EFF-26C5B75398B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A72EACD-45F9-4AEA-8EFF-26C5B75398B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/CrawlCtrl.Reader/Constants.cs
+++ b/src/CrawlCtrl.Reader/Constants.cs
@@ -1,0 +1,10 @@
+namespace CrawlCtrl.Reader
+{
+    public static class Constants
+    {
+        public static class HttpClient
+        {
+            public static string Name = "CrawlCtrl.Reader.LoadFile";
+        }
+    }
+}

--- a/src/CrawlCtrl.Reader/CrawlCtrl.Reader.csproj
+++ b/src/CrawlCtrl.Reader/CrawlCtrl.Reader.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>
+        <Company>Acidus</Company>
+        <Description>Convenient wrapper for the CrawlCtrl deserializer, that makes it easy to load and deserialize robots.txt files.</Description>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageTags>robots.txt;robots;crawler;crawling;sitemap</PackageTags>
+        <Title>CrawlCtrl.Reader</Title>
+        <Copyright>Copyright (c) Acidus 2023</Copyright>
+        <PackageProjectUrl>https://github.com/CrawlCtrl/CrawlCtrl</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <RepositoryUrl>https://github.com/CrawlCtrl/CrawlCtrl</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="../../assets/icon.png" Pack="true" PackagePath="\" Visible="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CrawlCtrl\CrawlCtrl.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/CrawlCtrl.Reader/HttpClientExtensions.cs
+++ b/src/CrawlCtrl.Reader/HttpClientExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Net.Http;
+
+namespace CrawlCtrl.Reader
+{
+    internal static class HttpClientExtensions
+    {
+        public static HttpClient ConfigureUserAgent(this HttpClient httpClient, IUserAgent userAgent)
+        {
+            if (httpClient is null)
+            {
+                throw new ArgumentNullException(nameof(httpClient));
+            }
+
+            if (userAgent is null)
+            {
+                throw new ArgumentNullException(nameof(userAgent));
+            }
+
+            if (userAgent is KeepUserAgent)
+            {
+                return httpClient;
+            }
+            
+            httpClient.DefaultRequestHeaders.UserAgent.Clear();
+
+            switch (userAgent)
+            {
+                case StringUserAgent userAgentData when userAgentData.Validate:
+                    httpClient.DefaultRequestHeaders.Add("User-Agent", userAgentData.UserAgent);
+                    break;
+                case StringUserAgent userAgentData:
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentData.UserAgent);
+                    break;
+                case ProductInfoUserAgent userAgentData:
+                    foreach (var value in userAgentData.Values)
+                    {
+                        httpClient.DefaultRequestHeaders.UserAgent.Add(value);
+                    }
+                    break;
+            }
+            
+            return httpClient;
+        }
+    }
+}

--- a/src/CrawlCtrl.Reader/IRobotsReader.cs
+++ b/src/CrawlCtrl.Reader/IRobotsReader.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CrawlCtrl.Reader
+{
+    public interface IRobotsReader
+    {
+        IReadOnlyCollection<Line> GetLines(string uriString, RobotsReaderOptions options = null);
+        Task<IReadOnlyCollection<Line>> GetLinesAsync(string uriString, RobotsReaderOptions options = null);
+        IReadOnlyCollection<Line> GetLines(Uri uri, RobotsReaderOptions options = null);
+        Task<IReadOnlyCollection<Line>> GetLinesAsync(Uri uri, RobotsReaderOptions options = null);
+    }
+}

--- a/src/CrawlCtrl.Reader/ImmutableRobotsReaderOptions.cs
+++ b/src/CrawlCtrl.Reader/ImmutableRobotsReaderOptions.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace CrawlCtrl.Reader
+{
+    internal sealed class ImmutableRobotsReaderOptions
+    {
+        public ImmutableRobotsReaderOptions(IUserAgent userAgent, RobotsDeserializerOptions deserializerOptions)
+        {
+            UserAgent = userAgent ?? throw new ArgumentNullException(nameof(userAgent));
+            DeserializerOptions = deserializerOptions ?? throw new ArgumentNullException(nameof(deserializerOptions));
+        }
+
+        public IUserAgent UserAgent { get; }
+        public RobotsDeserializerOptions DeserializerOptions { get; }
+    }
+}

--- a/src/CrawlCtrl.Reader/Properties/AssemblyInfo.cs
+++ b/src/CrawlCtrl.Reader/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("CrawlCtrl.Reader.UnitTests")]
+[assembly:InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/CrawlCtrl.Reader/RobotsReader.cs
+++ b/src/CrawlCtrl.Reader/RobotsReader.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace CrawlCtrl.Reader
+{
+    public sealed class RobotsReader : IRobotsReader
+    {
+        private readonly IRobotsDeserializer _robotsDeserializer;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public RobotsReader(IRobotsDeserializer robotsDeserializer, IHttpClientFactory httpClientFactory)
+        {
+            _robotsDeserializer = robotsDeserializer ?? throw new ArgumentNullException(nameof(robotsDeserializer));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        }
+
+        public IReadOnlyCollection<Line> GetLines(string uriString, RobotsReaderOptions options = null)
+        {
+            if (uriString is null)
+            {
+                throw new ArgumentNullException(nameof(uriString));
+            }
+            
+            return GetLinesAsync(uriString, options).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+        
+        public Task<IReadOnlyCollection<Line>> GetLinesAsync(string uriString, RobotsReaderOptions options = null)
+        {
+            if (uriString is null)
+            {
+                throw new ArgumentNullException(nameof(uriString));
+            }
+
+            var uri = new Uri(uriString);
+
+            return GetLinesAsync(uri, options);
+        }
+        
+        public IReadOnlyCollection<Line> GetLines(Uri uri, RobotsReaderOptions options = null)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+            
+            return GetLinesAsync(uri, options).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+        
+        public Task<IReadOnlyCollection<Line>> GetLinesAsync(Uri uri, RobotsReaderOptions options = null)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            return LoadAndDeserializeFileAsync(uri, options);
+        }
+
+        private async Task<IReadOnlyCollection<Line>> LoadAndDeserializeFileAsync(Uri uri, RobotsReaderOptions options = null)
+        {
+            var immutableOptions = (options ?? new RobotsReaderOptions()).ToImmutable();
+            
+            var httpClient = _httpClientFactory.CreateClient(Constants.HttpClient.Name);
+            httpClient.ConfigureUserAgent(immutableOptions.UserAgent);
+            
+            using (var contentStream = await httpClient.GetStreamAsync(uri))
+            {
+                return await _robotsDeserializer.GetDeserializedLinesAsync(contentStream, immutableOptions.DeserializerOptions);
+            }
+        }
+    }
+}

--- a/src/CrawlCtrl.Reader/RobotsReaderOptions.cs
+++ b/src/CrawlCtrl.Reader/RobotsReaderOptions.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace CrawlCtrl.Reader
+{
+    public sealed class RobotsReaderOptions
+    {
+        private IUserAgent _userAgent = new KeepUserAgent();
+        private RobotsDeserializerOptions _deserializerOptions = new RobotsDeserializerOptions();
+
+        public IUserAgent UserAgent
+        {
+            get => _userAgent;
+            set => _userAgent = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public RobotsDeserializerOptions DeserializerOptions
+        {
+            get => _deserializerOptions;
+            set => _deserializerOptions = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        internal ImmutableRobotsReaderOptions ToImmutable()
+        {
+            return new ImmutableRobotsReaderOptions(
+                userAgent: _userAgent,
+                deserializerOptions: _deserializerOptions
+            );
+        }
+    }
+}

--- a/src/CrawlCtrl.Reader/UserAgent.cs
+++ b/src/CrawlCtrl.Reader/UserAgent.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+
+namespace CrawlCtrl.Reader
+{
+    public interface IUserAgent
+    {
+        
+    }
+
+    public sealed class StringUserAgent : IUserAgent
+    {
+        public StringUserAgent(string userAgent, bool validate = true)
+        {
+            UserAgent = userAgent ?? throw new ArgumentNullException(nameof(userAgent));
+            Validate = validate;
+        }
+
+        public string UserAgent { get; }
+        public bool Validate { get; }
+    }
+
+    public sealed class ProductInfoUserAgent : IUserAgent
+    {
+        public ProductInfoUserAgent(IEnumerable<ProductInfoHeaderValue> values)
+        {
+            Values = values?.ToList().AsReadOnly() ?? throw new ArgumentNullException(nameof(values));
+        }
+        
+        public IReadOnlyCollection<ProductInfoHeaderValue> Values { get; }
+    }
+
+    public sealed class NoUserAgent : IUserAgent
+    {
+        
+    }
+
+    public sealed class KeepUserAgent : IUserAgent
+    {
+        
+    }
+}

--- a/test/CrawlCtrl.Reader.UnitTests/ConfiguringKeepUserAgentTests.cs
+++ b/test/CrawlCtrl.Reader.UnitTests/ConfiguringKeepUserAgentTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CrawlCtrl.Reader.UnitTests;
+
+public sealed class ConfiguringKeepUserAgentTests
+{
+    [Fact]
+    public void WHEN_Configuring_keep_user_agent_WHILE_User_agent_not_predefined_THEN_No_user_agent_configured()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+
+        var userAgentConfiguration = new KeepUserAgent();
+        
+        // Act
+        httpClient.ConfigureUserAgent(userAgentConfiguration);
+
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+    }
+    
+    [Fact]
+    public void WHEN_Configuring_keep_user_agent_WHILE_User_agent_predefined_THEN_Keep_predefined_user_agent()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithUserAgent();
+
+        var userAgentConfiguration = new KeepUserAgent();
+
+        var expectedUserAgent = UserAgentTestHelper.PredefinedUserAgentValues;
+        
+        // Act
+        httpClient.ConfigureUserAgent(userAgentConfiguration);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedUserAgent, options => options.WithStrictOrdering());
+    }
+}

--- a/test/CrawlCtrl.Reader.UnitTests/ConfiguringNoUserAgentTests.cs
+++ b/test/CrawlCtrl.Reader.UnitTests/ConfiguringNoUserAgentTests.cs
@@ -1,0 +1,36 @@
+using Xunit;
+
+namespace CrawlCtrl.Reader.UnitTests;
+
+public sealed class ConfiguringNoUserAgentTests
+{
+    [Fact]
+    public void WHEN_Configuring_no_user_agent_WHILE_User_agent_not_predefined_THEN_No_user_agent_configured()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+
+        var userAgentConfiguration = new NoUserAgent();
+        
+        // Act
+        httpClient.ConfigureUserAgent(userAgentConfiguration);
+
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+    }
+    
+    [Fact]
+    public void WHEN_Configuring_no_user_agent_WHILE_User_agent_predefined_THEN_No_user_agent_configured()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithUserAgent();
+
+        var userAgentConfiguration = new NoUserAgent();
+        
+        // Act
+        httpClient.ConfigureUserAgent(userAgentConfiguration);
+
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+    }
+}

--- a/test/CrawlCtrl.Reader.UnitTests/ConfiguringUserAgentWithProductInfoValuesTests.cs
+++ b/test/CrawlCtrl.Reader.UnitTests/ConfiguringUserAgentWithProductInfoValuesTests.cs
@@ -1,0 +1,67 @@
+using System.Net.Http.Headers;
+using FluentAssertions;
+using Xunit;
+
+namespace CrawlCtrl.Reader.UnitTests;
+
+public sealed class ConfiguringUserAgentWithProductInfoValuesTests
+{
+    [Fact]
+    public void WHILE_Http_client_has_user_agent_THEN_User_agent_is_replaced()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithUserAgent();
+
+        var expectedStartUserAgent = UserAgentTestHelper.PredefinedUserAgentValues;
+        var expectedEndUserAgent = UserAgentTestHelper.NewValidUserAgentValues;
+        
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedStartUserAgent, options => options.WithStrictOrdering());
+
+        // Act
+        var userAgent = new ProductInfoUserAgent(UserAgentTestHelper.NewValidUserAgentValues);
+        httpClient.ConfigureUserAgent(userAgent);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedEndUserAgent, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void WHILE_Http_client_has_no_user_agent_THEN_User_agent_is_set()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+
+        var expectedEndUserAgent = UserAgentTestHelper.NewValidUserAgentValues;
+        
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+
+        // Act
+        var userAgent = new ProductInfoUserAgent(UserAgentTestHelper.NewValidUserAgentValues);
+        httpClient.ConfigureUserAgent(userAgent);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedEndUserAgent, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void WHEN_Values_are_empty_THEN_User_agent_is_not_set()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+        
+        // Act
+        var userAgent = new ProductInfoUserAgent(Enumerable.Empty<ProductInfoHeaderValue>());
+        httpClient.ConfigureUserAgent(userAgent);
+        
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+    }
+}

--- a/test/CrawlCtrl.Reader.UnitTests/ConfiguringUserAgentWithStringTests.cs
+++ b/test/CrawlCtrl.Reader.UnitTests/ConfiguringUserAgentWithStringTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CrawlCtrl.Reader.UnitTests;
+
+public sealed class ConfiguringUserAgentWithStringTests
+{
+    [Fact]
+    public void WHILE_Http_client_has_user_agent_THEN_User_agent_is_replaced()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithUserAgent();
+
+        var expectedStartUserAgent = UserAgentTestHelper.PredefinedUserAgentValues;
+        var expectedEndUserAgent = UserAgentTestHelper.NewValidUserAgentValues;
+        
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedStartUserAgent, options => options.WithStrictOrdering());
+
+        // Act
+        var userAgent = new StringUserAgent(UserAgentTestHelper.NewValidUserAgentString);
+        httpClient.ConfigureUserAgent(userAgent);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedEndUserAgent, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void WHILE_Http_client_has_no_user_agent_THEN_User_agent_is_set()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+
+        var expectedEndUserAgent = UserAgentTestHelper.NewValidUserAgentValues;
+        
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+
+        // Act
+        var userAgent = new StringUserAgent(UserAgentTestHelper.NewValidUserAgentString);
+        httpClient.ConfigureUserAgent(userAgent);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedEndUserAgent, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void WHEN_User_agent_is_valid_WHEN_Validating_user_agent_THEN_User_agent_is_set()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+
+        var expectedUserAgent = UserAgentTestHelper.NewValidUserAgentValues;
+
+        // Act
+        var userAgent = new StringUserAgent(
+            userAgent: UserAgentTestHelper.NewValidUserAgentString,
+            validate: true
+        );
+        httpClient.ConfigureUserAgent(userAgent);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedUserAgent, options => options.WithStrictOrdering());
+    }
+    
+    [Fact]
+    public void WHEN_User_agent_is_valid_WHEN_Not_validating_user_agent_THEN_User_agent_is_set()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+
+        var expectedUserAgent = UserAgentTestHelper.NewValidUserAgentValues;
+
+        // Act
+        var userAgent = new StringUserAgent(
+            userAgent: UserAgentTestHelper.NewValidUserAgentString,
+            validate: false
+        );
+        httpClient.ConfigureUserAgent(userAgent);
+
+        // Assert
+        httpClient.DefaultRequestHeaders.UserAgent
+            .Should()
+            .BeEquivalentTo(expectedUserAgent, options => options.WithStrictOrdering());
+    }
+    
+    [Fact]
+    public void WHEN_User_agent_is_invalid_WHEN_Validating_user_agent_THEN_Throw_exception()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+        
+        // Act & Assert
+        var userAgent = new StringUserAgent(
+            userAgent: UserAgentTestHelper.NewInvalidUserAgentString,
+            validate: true
+        );
+        Assert.Throws<FormatException>(() => httpClient.ConfigureUserAgent(userAgent));
+    }
+    
+    [Fact]
+    public void WHEN_User_agent_is_invalid_WHEN_Not_validating_user_agent_THEN_User_agent_is_not_set()
+    {
+        // Arrange
+        var httpClient = UserAgentTestHelper.HttpClientWithoutUserAgent();
+        
+        // Act
+        var userAgent = new StringUserAgent(
+            userAgent: UserAgentTestHelper.NewInvalidUserAgentString,
+            validate: false
+        );
+        httpClient.ConfigureUserAgent(userAgent);
+        
+        // Assert
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
+    }
+}

--- a/test/CrawlCtrl.Reader.UnitTests/CrawlCtrl.Reader.UnitTests.csproj
+++ b/test/CrawlCtrl.Reader.UnitTests/CrawlCtrl.Reader.UnitTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="FluentAssertions" Version="6.12.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+      <PackageReference Include="NSubstitute" Version="5.1.0" />
+      <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+      <PackageReference Include="xunit" Version="2.6.5" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\CrawlCtrl.Reader\CrawlCtrl.Reader.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/CrawlCtrl.Reader.UnitTests/MappingOptionsToImmutableOptionsTests.cs
+++ b/test/CrawlCtrl.Reader.UnitTests/MappingOptionsToImmutableOptionsTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CrawlCtrl.Reader.UnitTests;
+
+public sealed class MappingOptionsToImmutableOptionsTests
+{
+    [Fact]
+    public void THEN_User_agent_options_are_mapped_to_immutable_options()
+    {
+        // Arrange
+        var options = new RobotsReaderOptions
+        {
+            UserAgent = new StringUserAgent("Test", false)
+        };
+
+        var expectedUserAgent = options.UserAgent;
+
+        // Act
+        var immutableOptions = options.ToImmutable();
+
+        // Assert
+        immutableOptions.UserAgent.Should().BeEquivalentTo(expectedUserAgent);
+    }
+    
+    [Fact]
+    public void THEN_Deserializer_options_are_mapped_to_immutable_options()
+    {
+        // Arrange
+        var options = new RobotsReaderOptions
+        {
+            DeserializerOptions = new RobotsDeserializerOptions
+            {
+                IncludeComments = true,
+                IncludeUnknownDirectives = true
+            }
+        };
+
+        var expectedDeserializerOptions = options.DeserializerOptions;
+        
+        // Act
+        var immutableOptions = options.ToImmutable();
+        
+        // Assert
+        immutableOptions.DeserializerOptions.Should().BeEquivalentTo(expectedDeserializerOptions);
+    }
+}

--- a/test/CrawlCtrl.Reader.UnitTests/UserAgentTestHelper.cs
+++ b/test/CrawlCtrl.Reader.UnitTests/UserAgentTestHelper.cs
@@ -1,0 +1,34 @@
+using System.Net.Http.Headers;
+
+namespace CrawlCtrl.Reader.UnitTests;
+
+internal sealed class UserAgentTestHelper
+{
+    public const string NewValidUserAgentString = "New/3.2.1 (It is very awesome)";
+    public static ProductInfoHeaderValue[] NewValidUserAgentValues =
+    [
+        new ProductInfoHeaderValue("New", "3.2.1"),
+        new ProductInfoHeaderValue("(It is very awesome)")
+    ];
+
+    public const string NewInvalidUserAgentString = "I'm an idiot sandwich // OMG";
+
+    public const string PredefinedUserAgentString = "Predefined/1.2.3 (It is awesome)";
+    public static ProductInfoHeaderValue[] PredefinedUserAgentValues =
+    [
+        new ProductInfoHeaderValue("Predefined", "1.2.3"),
+        new ProductInfoHeaderValue("(It is awesome)")
+    ];
+    
+    public static HttpClient HttpClientWithUserAgent() {
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("User-Agent", PredefinedUserAgentString);
+        return httpClient;
+    }
+    
+    public static HttpClient HttpClientWithoutUserAgent() {
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.UserAgent.Clear();
+        return httpClient;
+    }
+}


### PR DESCRIPTION
Moved CrawlCtrl.Reader from a separate solution/repo to this solution/repo.

This has been done since the core CrawlCtrl project are going to follow eachother 1:1. A release of the CrawlCtrl package results in the new release of CrawlCtrl.Reader with the same version. By moving the project into this solution we can automate the release and save time. WINNER WINNER CHICKEN DINNER!