### PR TITLE
Added .NET DI support for CrawlCtrl.Reader

### DIFF
--- a/CrawlCtrl.sln
+++ b/CrawlCtrl.sln
@@ -17,6 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader", "src\Cra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader.UnitTests", "test\CrawlCtrl.Reader.UnitTests\CrawlCtrl.Reader.UnitTests.csproj", "{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader.DependencyInjection.DotNet", "src\CrawlCtrl.Reader.DependencyInjection.DotNet\CrawlCtrl.Reader.DependencyInjection.DotNet.csproj", "{9A407FCB-F8C8-411D-8B02-1114DC1FCC78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests", "test\CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests\CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests.csproj", "{977DE979-4DFF-4635-8D7C-96F2799016A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,5 +58,13 @@ Global
 		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F062B38C-D1ED-47F3-B5CA-973FDDC7222E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A407FCB-F8C8-411D-8B02-1114DC1FCC78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A407FCB-F8C8-411D-8B02-1114DC1FCC78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A407FCB-F8C8-411D-8B02-1114DC1FCC78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A407FCB-F8C8-411D-8B02-1114DC1FCC78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{977DE979-4DFF-4635-8D7C-96F2799016A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{977DE979-4DFF-4635-8D7C-96F2799016A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{977DE979-4DFF-4635-8D7C-96F2799016A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{977DE979-4DFF-4635-8D7C-96F2799016A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/CrawlCtrl.Extensions.Microsoft.DependencyInjection/CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/CrawlCtrl.Extensions.Microsoft.DependencyInjection/CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <Title>CrawlCtrl.Extensions.Microsoft.DependencyInjection</Title>
+        <Description>.NET dependency injection support for CrawlCtrl</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>
         <Company>Acidus</Company>
-        <Description>Dependency injection extensions for CrawlCtrl</Description>
+        <Copyright>Copyright (c) Acidus 2024</Copyright>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>robots.txt;robots;crawler;crawling;sitemap;di;dependency injection</PackageTags>
-        <Title>CrawlCtrl.Extensions.Microsoft.DependencyInjection</Title>
-        <Copyright>Copyright (c) Acidus 2023</Copyright>
         <PackageProjectUrl>https://github.com/CrawlCtrl/CrawlCtrl</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/CrawlCtrl/CrawlCtrl</RepositoryUrl>
@@ -16,16 +16,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" Condition="'$(TargetFramework)' == 'NET462_OR_GREATER'" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="../../assets/icon.png" Pack="true" PackagePath="\" Visible="false" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\CrawlCtrl\CrawlCtrl.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/CrawlCtrl.Extensions.Microsoft.DependencyInjection/CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/CrawlCtrl.Extensions.Microsoft.DependencyInjection/CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Title>CrawlCtrl.Extensions.Microsoft.DependencyInjection</Title>
         <Description>.NET dependency injection support for CrawlCtrl</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>

--- a/src/CrawlCtrl.Extensions.Microsoft.DependencyInjection/RobotsTxtServiceCollectionExtensions.cs
+++ b/src/CrawlCtrl.Extensions.Microsoft.DependencyInjection/RobotsTxtServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 
-// ReSharper disable once CheckNamespace
 namespace CrawlCtrl
 {
     public static class CrawlCtrlServiceCollectionExtensions

--- a/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrl.Reader.DependencyInjection.DotNet.csproj
+++ b/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrl.Reader.DependencyInjection.DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Title>CrawlCtrl.Reader.DependencyInjection.DotNet</Title>
         <Description>.NET dependency injection support for CrawlCtrl.Reader</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>

--- a/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrl.Reader.DependencyInjection.DotNet.csproj
+++ b/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrl.Reader.DependencyInjection.DotNet.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
-        <Title>CrawlCtrl</Title>
-        <Description>Deserialize robots.txt files</Description>
+        <Title>CrawlCtrl.Reader.DependencyInjection.DotNet</Title>
+        <Description>.NET dependency injection support for CrawlCtrl.Reader</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>
         <Company>Acidus</Company>
         <Copyright>Copyright (c) Acidus 2024</Copyright>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageTags>robots.txt;robots;crawler;crawling;sitemap</PackageTags>
+        <PackageTags>robots.txt;robots;crawler;crawling;sitemap;di;dependency injection;reader</PackageTags>
         <PackageProjectUrl>https://github.com/CrawlCtrl/CrawlCtrl</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/CrawlCtrl/CrawlCtrl</RepositoryUrl>
@@ -16,9 +16,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+      <ProjectReference Include="..\CrawlCtrl.Extensions.Microsoft.DependencyInjection\CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj" />
+      <ProjectReference Include="..\CrawlCtrl.Reader\CrawlCtrl.Reader.csproj" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <None Include="../../assets/icon.png" Pack="true" PackagePath="\" Visible="false" />
     </ItemGroup>

--- a/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrlReaderServiceCollectionExtensions.cs
+++ b/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrlReaderServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CrawlCtrl.Reader.DependencyInjection.DotNet
+{
+    public static class CrawlCtrlReaderServiceCollectionExtensions
+    {
+        public static IServiceCollection AddCrawlCtrlReader(this IServiceCollection services)
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddCrawlCtrl();
+            services.AddTransient<IRobotsReader, RobotsReader>();
+            services.AddHttpClient(Constants.HttpClient.Name, client =>
+            {
+                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("", ""));
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/CrawlCtrl.Reader/CrawlCtrl.Reader.csproj
+++ b/src/CrawlCtrl.Reader/CrawlCtrl.Reader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Title>CrawlCtrl.Reader</Title>
         <Description>Convenient wrapper for the CrawlCtrl deserializer, that makes it easy to load and deserialize robots.txt files</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>

--- a/src/CrawlCtrl.Reader/CrawlCtrl.Reader.csproj
+++ b/src/CrawlCtrl.Reader/CrawlCtrl.Reader.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <Title>CrawlCtrl.Reader</Title>
+        <Description>Convenient wrapper for the CrawlCtrl deserializer, that makes it easy to load and deserialize robots.txt files</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>
         <Company>Acidus</Company>
-        <Description>Convenient wrapper for the CrawlCtrl deserializer, that makes it easy to load and deserialize robots.txt files.</Description>
+        <Copyright>Copyright (c) Acidus 2024</Copyright>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>robots.txt;robots;crawler;crawling;sitemap</PackageTags>
-        <Title>CrawlCtrl.Reader</Title>
-        <Copyright>Copyright (c) Acidus 2023</Copyright>
         <PackageProjectUrl>https://github.com/CrawlCtrl/CrawlCtrl</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/CrawlCtrl/CrawlCtrl</RepositoryUrl>

--- a/src/CrawlCtrl/CrawlCtrl.csproj
+++ b/src/CrawlCtrl/CrawlCtrl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Title>CrawlCtrl</Title>
         <Description>Deserialize robots.txt files</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>

--- a/test/CrawlCtrl.IntegrationTests/CrawlCtrl.IntegrationTests.csproj
+++ b/test/CrawlCtrl.IntegrationTests/CrawlCtrl.IntegrationTests.csproj
@@ -29,11 +29,9 @@
       <Content Update="robots_empty.txt">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
-      <None Remove="robots_empty.txt" />
       <Content Include="robots_empty.txt">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
-      <None Remove="robots_only_sitemaps.txt" />
       <Content Include="robots_only_sitemaps.txt">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/test/CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests/CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests.csproj
+++ b/test/CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests/CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <WarningsAsErrors>Nullable</WarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+      <PackageReference Include="xunit" Version="2.6.6" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\CrawlCtrl.Reader.DependencyInjection.DotNet\CrawlCtrl.Reader.DependencyInjection.DotNet.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests/DependencyInjectionTests.cs
+++ b/test/CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests/DependencyInjectionTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test;
+namespace CrawlCtrl.Reader.DependencyInjection.DotNet.UnitTests;
 
 public sealed class DependencyInjectionTests
 {
@@ -12,7 +12,7 @@ public sealed class DependencyInjectionTests
         var serviceCollection = new ServiceCollection();
 
         // Act
-        serviceCollection.AddCrawlCtrl();
+        serviceCollection.AddCrawlCtrlReader();
         
         // Assert
         serviceCollection.BuildServiceProvider(new ServiceProviderOptions


### PR DESCRIPTION
Added project that adds .NET DI support to CrawlCtrl.Reader + tests.

Also; made some adjustments to the NuGet information in various csproj files.

Replaced targeting of .NET 4.6.1 with 4.6.2 in NuGet projects per recommendation from Microsoft: https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting