### PR TITLE
Renamed CrawlCtrl DI project

### DIFF
--- a/CrawlCtrl.sln
+++ b/CrawlCtrl.sln
@@ -9,9 +9,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.IntegrationTests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.UnitTests", "test\CrawlCtrl.UnitTests\CrawlCtrl.UnitTests.csproj", "{257C71A6-655D-42C6-9CC1-25BBA7BE5CAB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Extensions.Microsoft.DependencyInjection", "src\CrawlCtrl.Extensions.Microsoft.DependencyInjection\CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj", "{38AA5550-CC5E-4577-98DC-A4EC000651F2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.DependencyInjection.DotNet", "src\CrawlCtrl.DependencyInjection.DotNet\CrawlCtrl.DependencyInjection.DotNet.csproj", "{38AA5550-CC5E-4577-98DC-A4EC000651F2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test", "test\CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test\CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test.csproj", "{C2AD4BB5-64AB-488B-B89D-2F85B41173FA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.DependencyInjection.DotNet.UnitTests", "test\CrawlCtrl.DependencyInjection.DotNet.UnitTests\CrawlCtrl.DependencyInjection.DotNet.UnitTests.csproj", "{C2AD4BB5-64AB-488B-B89D-2F85B41173FA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrawlCtrl.Reader", "src\CrawlCtrl.Reader\CrawlCtrl.Reader.csproj", "{8A72EACD-45F9-4AEA-8EFF-26C5B75398B9}"
 EndProject

--- a/src/CrawlCtrl.DependencyInjection.DotNet/CrawlCtrl.DependencyInjection.DotNet.csproj
+++ b/src/CrawlCtrl.DependencyInjection.DotNet/CrawlCtrl.DependencyInjection.DotNet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
-        <Title>CrawlCtrl.Extensions.Microsoft.DependencyInjection</Title>
+        <Title>CrawlCtrl.DependencyInjection.DotNet</Title>
         <Description>.NET dependency injection support for CrawlCtrl</Description>
         <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>
         <Company>Acidus</Company>

--- a/src/CrawlCtrl.DependencyInjection.DotNet/RobotsTxtServiceCollectionExtensions.cs
+++ b/src/CrawlCtrl.DependencyInjection.DotNet/RobotsTxtServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 
+// ReSharper disable once CheckNamespace
 namespace CrawlCtrl
 {
     public static class CrawlCtrlServiceCollectionExtensions

--- a/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrl.Reader.DependencyInjection.DotNet.csproj
+++ b/src/CrawlCtrl.Reader.DependencyInjection.DotNet/CrawlCtrl.Reader.DependencyInjection.DotNet.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\CrawlCtrl.Extensions.Microsoft.DependencyInjection\CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj" />
+      <ProjectReference Include="..\CrawlCtrl.DependencyInjection.DotNet\CrawlCtrl.DependencyInjection.DotNet.csproj" />
       <ProjectReference Include="..\CrawlCtrl.Reader\CrawlCtrl.Reader.csproj" />
     </ItemGroup>
 

--- a/test/CrawlCtrl.DependencyInjection.DotNet.UnitTests/CrawlCtrl.DependencyInjection.DotNet.UnitTests.csproj
+++ b/test/CrawlCtrl.DependencyInjection.DotNet.UnitTests/CrawlCtrl.DependencyInjection.DotNet.UnitTests.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\CrawlCtrl.Extensions.Microsoft.DependencyInjection\CrawlCtrl.Extensions.Microsoft.DependencyInjection.csproj" />
+      <ProjectReference Include="..\..\src\CrawlCtrl.DependencyInjection.DotNet\CrawlCtrl.DependencyInjection.DotNet.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/CrawlCtrl.DependencyInjection.DotNet.UnitTests/DependencyInjectionTests.cs
+++ b/test/CrawlCtrl.DependencyInjection.DotNet.UnitTests/DependencyInjectionTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace CrawlCtrl.Extensions.Microsoft.DependencyInjection.Test;
+namespace CrawlCtrl.DependencyInjection.DotNet.UnitTests;
 
 public sealed class DependencyInjectionTests
 {


### PR DESCRIPTION
Renamed the CrawlCtrl .NET DI project from CrawlCtrl.Extensions.Microsoft.DependencyInjection to CrawlCtrl.DependencyInjection.DotNet. Unit test project aligned with the name.