### PR TITLE
Use immutable options while deserializing

### DIFF
--- a/src/CrawlCtrl/Deserialization/ILineDeserializer.cs
+++ b/src/CrawlCtrl/Deserialization/ILineDeserializer.cs
@@ -2,6 +2,6 @@ namespace CrawlCtrl.Deserialization
 {
     internal interface ILineDeserializer<out TLine> where TLine : Line
     {
-        TLine Deserialize(string directive, string value, string comment, string line);
+        TLine Deserialize(string directive, string value, string comment, string line, ImmutableRobotsDeserializerOptions options);
     }
 }

--- a/src/CrawlCtrl/Deserialization/LineDeserializationCoordinator.cs
+++ b/src/CrawlCtrl/Deserialization/LineDeserializationCoordinator.cs
@@ -3,18 +3,18 @@ using System.Collections.Generic;
 
 namespace CrawlCtrl.Deserialization
 {
-    internal class LineDeserializationCoordinator
+    internal sealed class LineDeserializationCoordinator
     {
-        private readonly RobotsDeserializerOptions _options;
+        private readonly ImmutableRobotsDeserializerOptions _options;
+        private readonly IReadOnlyDictionary<string, ILineDeserializer<Line>> _lineDeserializers;
 
-        public LineDeserializationCoordinator(IReadOnlyDictionary<string, ILineDeserializer<Line>> lineDeserializers, RobotsDeserializerOptions options)
+        public LineDeserializationCoordinator(IReadOnlyDictionary<string, ILineDeserializer<Line>> lineDeserializers, ImmutableRobotsDeserializerOptions options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            
-            LineDeserializers = lineDeserializers ?? throw new ArgumentNullException(nameof(lineDeserializers));
+            _lineDeserializers = lineDeserializers ?? throw new ArgumentNullException(nameof(lineDeserializers));
         }
-        
-        public readonly IReadOnlyDictionary<string, ILineDeserializer<Line>> LineDeserializers;
+
+        internal IReadOnlyDictionary<string, ILineDeserializer<Line>> LineDeserializers => _lineDeserializers;
 
         public Line Deserialize(string line)
         {
@@ -57,7 +57,8 @@ namespace CrawlCtrl.Deserialization
                     lineComponents.Directive,
                     lineComponents.Value,
                     lineComponents.Comment,
-                    line
+                    line,
+                    _options
                 );
 
                 return deserializedLine;

--- a/src/CrawlCtrl/Deserialization/LineDeserializationCoordinatorFactory.cs
+++ b/src/CrawlCtrl/Deserialization/LineDeserializationCoordinatorFactory.cs
@@ -1,21 +1,22 @@
+using System;
 using System.Collections.Generic;
 
 namespace CrawlCtrl.Deserialization
 {
     internal static class LineDeserializationCoordinatorFactory
     {
-        public static LineDeserializationCoordinator Build(RobotsDeserializerOptions options)
+        public static LineDeserializationCoordinator Build(ImmutableRobotsDeserializerOptions options)
         {
             if (options is null)
             {
-                options = new RobotsDeserializerOptions();
+                throw new ArgumentNullException(nameof(options));
             }
             
             var lineInterpreters = new Dictionary<string, ILineDeserializer<Line>>();
 
-            if (options.IncludeSitemaps)
+            if (options.SitemapPolicy != SitemapPolicy.Ignore)
             {
-                lineInterpreters[Constants.Directives.Sitemap] = new SitemapLineDeserializer(options.SitemapsInclusionScope);
+                lineInterpreters[Constants.Directives.Sitemap] = new SitemapLineDeserializer();
             }
             
             return new LineDeserializationCoordinator(lineInterpreters, options);

--- a/src/CrawlCtrl/ImmutableOptionsMappingExtensions.cs
+++ b/src/CrawlCtrl/ImmutableOptionsMappingExtensions.cs
@@ -1,0 +1,23 @@
+namespace CrawlCtrl
+{
+    internal static class ImmutableOptionsMappingExtensions
+    {
+        public static ImmutableRobotsDeserializerOptions ToImmutableOrDefault(this RobotsDeserializerOptions options)
+        {
+            if (options is null)
+            {
+                options = new RobotsDeserializerOptions();
+            }
+            
+            var immutableOptions = new ImmutableRobotsDeserializerOptions(
+                includeComments: options.IncludeComments,
+                includeEmptyLines: options.IncludeEmptyLines,
+                includeInvalidLines: options.IncludeInvalidLines,
+                includeUnknownDirectives: options.IncludeUnknownDirectives,
+                sitemapPolicy: options.SitemapPolicy
+            );
+
+            return immutableOptions;
+        }
+    }
+}

--- a/src/CrawlCtrl/ImmutableRobotsDeserializerOptions.cs
+++ b/src/CrawlCtrl/ImmutableRobotsDeserializerOptions.cs
@@ -1,0 +1,21 @@
+namespace CrawlCtrl
+{
+    internal sealed class ImmutableRobotsDeserializerOptions
+    {
+        internal ImmutableRobotsDeserializerOptions(bool includeComments, bool includeEmptyLines, bool includeInvalidLines, bool includeUnknownDirectives, SitemapPolicy sitemapPolicy)
+        {
+            IncludeComments = includeComments;
+            IncludeEmptyLines = includeEmptyLines;
+            IncludeInvalidLines = includeInvalidLines;
+            IncludeUnknownDirectives = includeUnknownDirectives;
+            SitemapPolicy = sitemapPolicy;
+        }
+
+        public bool IncludeComments { get; }
+        public bool IncludeEmptyLines { get; }
+        public bool IncludeInvalidLines { get; }
+        public bool IncludeUnknownDirectives { get; }
+        
+        public SitemapPolicy SitemapPolicy { get; }
+    }
+}

--- a/src/CrawlCtrl/InclusionScope.cs
+++ b/src/CrawlCtrl/InclusionScope.cs
@@ -1,9 +1,0 @@
-namespace CrawlCtrl
-{
-    public enum InclusionScope
-    {
-        All = 0,
-        ValidOnly = 1,
-        InvalidOnly = 2
-    }
-}

--- a/src/CrawlCtrl/RobotsDeserializer.cs
+++ b/src/CrawlCtrl/RobotsDeserializer.cs
@@ -48,8 +48,9 @@ namespace CrawlCtrl
             {
                 throw new ArgumentNullException(nameof(robotsStreamReader));
             }
-
-            var lineDeserializationCoordinator = LineDeserializationCoordinatorFactory.Build(options);
+            
+            var immutableOptions = options.ToImmutableOrDefault();
+            var lineDeserializationCoordinator = LineDeserializationCoordinatorFactory.Build(immutableOptions);
 
             var lines = new List<Line>();
             while (robotsStreamReader.EndOfStream is false)
@@ -73,7 +74,8 @@ namespace CrawlCtrl
                 throw new ArgumentNullException(nameof(robotsStreamReader));
             }
             
-            var lineDeserializationCoordinator = LineDeserializationCoordinatorFactory.Build(options);
+            var immutableOptions = options.ToImmutableOrDefault();
+            var lineDeserializationCoordinator = LineDeserializationCoordinatorFactory.Build(immutableOptions);
             
             while (robotsStreamReader.EndOfStream is false)
             {
@@ -102,12 +104,8 @@ namespace CrawlCtrl
                 throw new ArgumentNullException(nameof(robotsStreamReader));
             }
             
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            var lineDeserializationCoordinator = LineDeserializationCoordinatorFactory.Build(options);
+            var immutableOptions = options.ToImmutableOrDefault();
+            var lineDeserializationCoordinator = LineDeserializationCoordinatorFactory.Build(immutableOptions);
             
             while (robotsStreamReader.EndOfStream is false)
             {

--- a/src/CrawlCtrl/RobotsDeserializerOptions.cs
+++ b/src/CrawlCtrl/RobotsDeserializerOptions.cs
@@ -7,7 +7,6 @@ namespace CrawlCtrl
         public bool IncludeInvalidLines { get; set; } = false;
         public bool IncludeUnknownDirectives { get; set; } = false;
         
-        public bool IncludeSitemaps { get; set; } = true;
-        public InclusionScope SitemapsInclusionScope { get; set; } = InclusionScope.ValidOnly;
+        public SitemapPolicy SitemapPolicy { get; set; } = SitemapPolicy.OnlyValid;
     }
 }

--- a/src/CrawlCtrl/SitemapPolicy.cs
+++ b/src/CrawlCtrl/SitemapPolicy.cs
@@ -1,0 +1,10 @@
+namespace CrawlCtrl
+{
+    public enum SitemapPolicy
+    {
+        Ignore,
+        OnlyValid,
+        OnlyInvalid,
+        All
+    }
+}

--- a/test/CrawlCtrl.IntegrationTests/CompleteRobotsTxtDeserializationTests.cs
+++ b/test/CrawlCtrl.IntegrationTests/CompleteRobotsTxtDeserializationTests.cs
@@ -14,8 +14,7 @@ public sealed class CompleteRobotsTxtDeserializationTests
         var expectedLines = RobotsTestData.CompleteRobotsTxt;
         var deserializationOptions = new RobotsDeserializerOptions
         {
-            IncludeSitemaps = true,
-            SitemapsInclusionScope = InclusionScope.All,
+            SitemapPolicy = SitemapPolicy.All,
             IncludeEmptyLines = true,
             IncludeInvalidLines = true,
             IncludeUnknownDirectives = true
@@ -43,8 +42,7 @@ public sealed class CompleteRobotsTxtDeserializationTests
         var expectedLines = RobotsTestData.CompleteRobotsTxt.Where(line => line is ValidSitemap);
         var deserializationOptions = new RobotsDeserializerOptions
         {
-            IncludeSitemaps = true,
-            SitemapsInclusionScope = InclusionScope.ValidOnly,
+            SitemapPolicy = SitemapPolicy.OnlyValid,
             IncludeEmptyLines = false,
             IncludeInvalidLines = false,
             IncludeUnknownDirectives = false

--- a/test/CrawlCtrl.IntegrationTests/EnumeratingDeserializedLinesTests.cs
+++ b/test/CrawlCtrl.IntegrationTests/EnumeratingDeserializedLinesTests.cs
@@ -10,8 +10,7 @@ public sealed class EnumeratingDeserializedLinesTests
     
     private readonly RobotsDeserializerOptions _deserializationOptions = new()
     {
-        IncludeSitemaps = true,
-        SitemapsInclusionScope = InclusionScope.All,
+        SitemapPolicy = SitemapPolicy.All,
         IncludeEmptyLines = true,
         IncludeInvalidLines = true,
         IncludeUnknownDirectives = true

--- a/test/CrawlCtrl.UnitTests/Deserialization/Coordinator/BuildLineDeserializationCoordinatorTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/Coordinator/BuildLineDeserializationCoordinatorTests.cs
@@ -11,8 +11,8 @@ public sealed class BuildLineDeserializationCoordinatorTests
         // Arrange
         var options = new RobotsDeserializerOptions
         {
-            IncludeSitemaps = true
-        };
+            SitemapPolicy = SitemapPolicy.OnlyValid
+        }.ToImmutableOrDefault();
         
         // Act
         var deserializationCoordinator = LineDeserializationCoordinatorFactory.Build(options);

--- a/test/CrawlCtrl.UnitTests/Deserialization/DeserializeEmptyLineTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/DeserializeEmptyLineTests.cs
@@ -18,7 +18,7 @@ public sealed class DeserializeEmptyLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeEmptyLines = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -41,7 +41,7 @@ public sealed class DeserializeEmptyLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeEmptyLines = false
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -64,7 +64,7 @@ public sealed class DeserializeEmptyLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeEmptyLines = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -85,7 +85,7 @@ public sealed class DeserializeEmptyLineTests
             {
                 IncludeEmptyLines = true,
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "";
@@ -108,7 +108,7 @@ public sealed class DeserializeEmptyLineTests
             {
                 IncludeEmptyLines = true,
                 IncludeComments = false
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "";
@@ -131,7 +131,7 @@ public sealed class DeserializeEmptyLineTests
             {
                 IncludeEmptyLines = true,
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "# Some comment";
@@ -155,7 +155,7 @@ public sealed class DeserializeEmptyLineTests
             {
                 IncludeEmptyLines = true,
                 IncludeComments = false
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "# Some comment";
@@ -181,7 +181,7 @@ public sealed class DeserializeEmptyLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeEmptyLines = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act

--- a/test/CrawlCtrl.UnitTests/Deserialization/DeserializeInvalidLineTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/DeserializeInvalidLineTests.cs
@@ -18,7 +18,7 @@ public sealed class DeserializeInvalidLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeInvalidLines = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -41,7 +41,7 @@ public sealed class DeserializeInvalidLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeInvalidLines = false
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -64,7 +64,7 @@ public sealed class DeserializeInvalidLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeInvalidLines = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -85,7 +85,7 @@ public sealed class DeserializeInvalidLineTests
             {
                 IncludeInvalidLines = true,
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "invalid";
@@ -108,7 +108,7 @@ public sealed class DeserializeInvalidLineTests
             {
                 IncludeInvalidLines = true,
                 IncludeComments = false
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "invalid";
@@ -131,7 +131,7 @@ public sealed class DeserializeInvalidLineTests
             {
                 IncludeInvalidLines = true,
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "invalid # Some comment";
@@ -155,7 +155,7 @@ public sealed class DeserializeInvalidLineTests
             {
                 IncludeInvalidLines = true,
                 IncludeComments = false
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "invalid # Some comment";
@@ -181,7 +181,7 @@ public sealed class DeserializeInvalidLineTests
             options: new RobotsDeserializerOptions
             {
                 IncludeInvalidLines = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act

--- a/test/CrawlCtrl.UnitTests/Deserialization/DeserializeInvalidSitemapTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/DeserializeInvalidSitemapTests.cs
@@ -5,6 +5,10 @@ namespace CrawlCtrl.UnitTests.Deserialization;
 
 public sealed class DeserializeInvalidSitemapTests
 {
+    private readonly SitemapLineDeserializer _sitemapLineDeserializer = new ();
+    private readonly ImmutableRobotsDeserializerOptions _options =
+        new RobotsDeserializerOptions { SitemapPolicy = SitemapPolicy.OnlyInvalid }.ToImmutableOrDefault();
+    
     private const string SitemapDirective = "sitemap";
     private const string InvalidSitemapValue = "";
     
@@ -16,12 +20,10 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Directive_is_set_WHILE_Deserializing_invalid_sitemap_THEN_Set_directive_on_invalid_sitemap(string directive)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         var expectedDirective = directive;
         
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: directive, value: InvalidSitemapValue, comment: null, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: directive, value: InvalidSitemapValue, comment: null, line: string.Empty, _options);
         
         // Assert
         var invalidSitemap = Assert.IsType<InvalidSitemap>(deserializedSitemap);
@@ -33,13 +35,11 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Directive_is_null_WHILE_Deserializing_invalid_sitemap_THEN_Throw_exception()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         const string? directive = null;
         
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => 
-            sitemapLineDeserializer.Deserialize(directive: directive, value: InvalidSitemapValue, comment: null, line: string.Empty)
+            _sitemapLineDeserializer.Deserialize(directive: directive, value: InvalidSitemapValue, comment: null, line: string.Empty, _options)
         );
 
         // Assert
@@ -47,33 +47,35 @@ public sealed class DeserializeInvalidSitemapTests
     }
 
     [Theory]
-    [InlineData(InclusionScope.All)]
-    [InlineData(InclusionScope.InvalidOnly)]
-    public void WHEN_Value_is_invalid_sitemap_WHILE_Including_invalid_sitemaps_THEN_Deserialize_invalid_sitemap(InclusionScope inclusionScope)
+    [InlineData(SitemapPolicy.All)]
+    [InlineData(SitemapPolicy.OnlyInvalid)]
+    public void WHEN_Value_is_invalid_sitemap_WHILE_Including_invalid_sitemaps_THEN_Deserialize_invalid_sitemap(SitemapPolicy sitemapPolicy)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(
-            inclusionScope: inclusionScope
-        );
+        var options = new RobotsDeserializerOptions
+        {
+            SitemapPolicy = sitemapPolicy
+        }.ToImmutableOrDefault();
 
         // Act
-        var sitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: string.Empty);
+        var sitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: string.Empty, options);
         
         // Assert
         Assert.IsType<InvalidSitemap>(sitemap);
     }
     
     [Theory]
-    [InlineData(InclusionScope.ValidOnly)]
-    public void WHEN_Value_is_invalid_sitemap_WHILE_Excluding_invalid_sitemaps_THEN_Return_null(InclusionScope inclusionScope)
+    [InlineData(SitemapPolicy.OnlyValid)]
+    public void WHEN_Value_is_invalid_sitemap_WHILE_Excluding_invalid_sitemaps_THEN_Return_null(SitemapPolicy sitemapPolicy)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(
-            inclusionScope: inclusionScope
-        );
+        var options = new RobotsDeserializerOptions
+        {
+            SitemapPolicy = sitemapPolicy
+        }.ToImmutableOrDefault();
 
         // Act
-        var sitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: string.Empty);
+        var sitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: string.Empty, options);
         
         // Assert
         Assert.Null(sitemap);
@@ -89,12 +91,10 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Value_is_set_WHILE_Deserializing_invalid_sitemap_THEN_Set_value_on_invalid_sitemap(string value)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         var expectedValue = value;
         
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty, _options);
         
         // Assert
         var invalidSitemap = Assert.IsType<InvalidSitemap>(deserializedSitemap);
@@ -106,13 +106,11 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Value_is_null_WHILE_Deserializing_invalid_sitemap_THEN_Throw_exception()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         const string? value = null;
         
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => 
-            sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty)
+            _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty, _options)
         );
 
         // Assert
@@ -129,12 +127,10 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Comment_is_set_WHILE_Deserializing_invalid_sitemap_THEN_Set_comment_on_invalid_sitemap(string comment)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         var expectedComment = comment;
 
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: comment, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: comment, line: string.Empty, _options);
         
         // Assert
         var invalidSitemap = Assert.IsType<InvalidSitemap>(deserializedSitemap);
@@ -146,13 +142,11 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Comment_is_null_WHILE_Deserializing_invalid_sitemap_THEN_Set_comment_on_invalid_sitemap()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         const string? comment = null;
         const string? expectedComment = comment;
 
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: comment, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: comment, line: string.Empty, _options);
         
         // Assert
         var invalidSitemap = Assert.IsType<InvalidSitemap>(deserializedSitemap);
@@ -167,12 +161,10 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Line_is_set_WHILE_Deserializing_invalid_sitemap_THEN_Set_full_line_on_invalid_sitemap(string line)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         var expectedLine = line;
 
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: line);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: line, _options);
         
         // Assert
         var invalidSitemap = Assert.IsType<InvalidSitemap>(deserializedSitemap);
@@ -184,13 +176,11 @@ public sealed class DeserializeInvalidSitemapTests
     public void WHEN_Line_is_null_WHILE_Deserializing_invalid_sitemap_THEN_Throw_exception()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.InvalidOnly);
-
         const string? line = null;
         
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => 
-            sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: line)
+            _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: InvalidSitemapValue, comment: null, line: line, _options)
         );
 
         // Assert

--- a/test/CrawlCtrl.UnitTests/Deserialization/DeserializeLineWithDeserializerTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/DeserializeLineWithDeserializerTests.cs
@@ -19,7 +19,7 @@ public sealed class DeserializeLineWithDeserializerTests
         
         var coordinator = new LineDeserializationCoordinator(
             lineDeserializers: lineDeserializers,
-            options: new RobotsDeserializerOptions()
+            options: new RobotsDeserializerOptions().ToImmutableOrDefault()
         );
 
         const string line = "test-directive: test-value # test comment";
@@ -28,7 +28,7 @@ public sealed class DeserializeLineWithDeserializerTests
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.DidNotReceiveWithAnyArgs().Deserialize(default, default, default, default);
+        _deserializerMock.DidNotReceiveWithAnyArgs().Deserialize(default, default, default, default, default);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public sealed class DeserializeLineWithDeserializerTests
         
         var coordinator = new LineDeserializationCoordinator(
             lineDeserializers: lineDeserializers,
-            options: new RobotsDeserializerOptions()
+            options: new RobotsDeserializerOptions().ToImmutableOrDefault()
         );
 
         const string line = "test-directive: test-value # test comment";
@@ -51,7 +51,7 @@ public sealed class DeserializeLineWithDeserializerTests
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.ReceivedWithAnyArgs(1).Deserialize(default, default, default, default);
+        _deserializerMock.ReceivedWithAnyArgs(1).Deserialize(default, default, default, default, default);
     }
     
     [Fact]
@@ -65,7 +65,7 @@ public sealed class DeserializeLineWithDeserializerTests
         
         var coordinator = new LineDeserializationCoordinator(
             lineDeserializers: lineDeserializers,
-            options: new RobotsDeserializerOptions()
+            options: new RobotsDeserializerOptions().ToImmutableOrDefault()
         );
 
         const string line = " test-directive: test-value # test comment";
@@ -75,7 +75,7 @@ public sealed class DeserializeLineWithDeserializerTests
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.Received(1).Deserialize(expectedDirective, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        _deserializerMock.Received(1).Deserialize(expectedDirective, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImmutableRobotsDeserializerOptions>());
     }
     
     [Theory]
@@ -93,14 +93,14 @@ public sealed class DeserializeLineWithDeserializerTests
         
         var coordinator = new LineDeserializationCoordinator(
             lineDeserializers: lineDeserializers,
-            options: new RobotsDeserializerOptions()
+            options: new RobotsDeserializerOptions().ToImmutableOrDefault()
         );
         
         // Act
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), expectedFullLine);
+        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), expectedFullLine, Arg.Any<ImmutableRobotsDeserializerOptions>());
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public sealed class DeserializeLineWithDeserializerTests
         
         var coordinator = new LineDeserializationCoordinator(
             lineDeserializers: lineDeserializers,
-            options: new RobotsDeserializerOptions()
+            options: new RobotsDeserializerOptions().ToImmutableOrDefault()
         );
 
         const string line = "test-directive: test-value # test comment";
@@ -124,7 +124,7 @@ public sealed class DeserializeLineWithDeserializerTests
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), expectedValue, Arg.Any<string>(), Arg.Any<string>());
+        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), expectedValue, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImmutableRobotsDeserializerOptions>());
     }
     
     [Fact]
@@ -141,7 +141,7 @@ public sealed class DeserializeLineWithDeserializerTests
             options: new RobotsDeserializerOptions
             {
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "test-directive: test-value # test comment";
@@ -151,7 +151,7 @@ public sealed class DeserializeLineWithDeserializerTests
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), Arg.Any<string>(), expectedComment, Arg.Any<string>());
+        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), Arg.Any<string>(), expectedComment, Arg.Any<string>(), Arg.Any<ImmutableRobotsDeserializerOptions>());
     }
 
     [Theory]
@@ -170,14 +170,14 @@ public sealed class DeserializeLineWithDeserializerTests
         
         var coordinator = new LineDeserializationCoordinator(
             lineDeserializers: lineDeserializers,
-            options: new RobotsDeserializerOptions()
+            options: new RobotsDeserializerOptions().ToImmutableOrDefault()
         );
         
         // Act
         coordinator.Deserialize(line);
 
         // Assert
-        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        _deserializerMock.Received(1).Deserialize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImmutableRobotsDeserializerOptions>());
     }
 
     public sealed class TestLine : Line

--- a/test/CrawlCtrl.UnitTests/Deserialization/DeserializeUnknownDirectiveTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/DeserializeUnknownDirectiveTests.cs
@@ -17,7 +17,7 @@ public sealed class DeserializeUnknownDirectiveTests
             options: new RobotsDeserializerOptions
             {
                 IncludeUnknownDirectives = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -39,7 +39,7 @@ public sealed class DeserializeUnknownDirectiveTests
             options: new RobotsDeserializerOptions
             {
                 IncludeUnknownDirectives = false
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -60,7 +60,7 @@ public sealed class DeserializeUnknownDirectiveTests
             options: new RobotsDeserializerOptions
             {
                 IncludeUnknownDirectives = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -84,7 +84,7 @@ public sealed class DeserializeUnknownDirectiveTests
             options: new RobotsDeserializerOptions
             {
                 IncludeUnknownDirectives = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act
@@ -105,7 +105,7 @@ public sealed class DeserializeUnknownDirectiveTests
             {
                 IncludeUnknownDirectives = true,
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "directive: value";
@@ -128,7 +128,7 @@ public sealed class DeserializeUnknownDirectiveTests
             {
                 IncludeUnknownDirectives = true,
                 IncludeComments = false
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "directive: value";
@@ -151,7 +151,7 @@ public sealed class DeserializeUnknownDirectiveTests
             {
                 IncludeUnknownDirectives = true,
                 IncludeComments = true
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "directive: value # Some comment";
@@ -175,7 +175,7 @@ public sealed class DeserializeUnknownDirectiveTests
             {
                 IncludeUnknownDirectives = true,
                 IncludeComments = false
-            }
+            }.ToImmutableOrDefault()
         );
 
         const string line = "directive: value # Some comment";
@@ -201,7 +201,7 @@ public sealed class DeserializeUnknownDirectiveTests
             options: new RobotsDeserializerOptions
             {
                 IncludeUnknownDirectives = true
-            }
+            }.ToImmutableOrDefault()
         );
         
         // Act

--- a/test/CrawlCtrl.UnitTests/Deserialization/DeserializeValidSitemapTests.cs
+++ b/test/CrawlCtrl.UnitTests/Deserialization/DeserializeValidSitemapTests.cs
@@ -5,6 +5,10 @@ namespace CrawlCtrl.UnitTests.Deserialization;
 
 public sealed class DeserializeValidSitemapTests
 {
+    private readonly SitemapLineDeserializer _sitemapLineDeserializer = new ();
+    private readonly ImmutableRobotsDeserializerOptions _options =
+        new RobotsDeserializerOptions { SitemapPolicy = SitemapPolicy.OnlyValid }.ToImmutableOrDefault();
+    
     private const string SitemapDirective = "sitemap";
     private const string ValidSitemapValue = "https://www.example.com/sitemap.xml";
     
@@ -16,12 +20,10 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Directive_is_set_WHILE_Deserializing_valid_sitemap_THEN_Set_directive_on_valid_sitemap(string directive)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         var expectedDirective = directive;
         
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: directive, value: ValidSitemapValue, comment: null, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: directive, value: ValidSitemapValue, comment: null, line: string.Empty, _options);
         
         // Assert
         var validSitemap = Assert.IsType<ValidSitemap>(deserializedSitemap);
@@ -33,13 +35,11 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Directive_is_null_WHILE_Deserializing_valid_sitemap_THEN_Throw_exception()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         const string? directive = null;
         
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => 
-            sitemapLineDeserializer.Deserialize(directive: directive, value: ValidSitemapValue, comment: null, line: string.Empty)
+            _sitemapLineDeserializer.Deserialize(directive: directive, value: ValidSitemapValue, comment: null, line: string.Empty, _options)
         );
 
         // Assert
@@ -47,33 +47,35 @@ public sealed class DeserializeValidSitemapTests
     }
 
     [Theory]
-    [InlineData(InclusionScope.All)]
-    [InlineData(InclusionScope.ValidOnly)]
-    public void WHEN_Value_is_valid_sitemap_WHILE_Including_valid_sitemaps_THEN_Deserialize_valid_sitemap(InclusionScope inclusionScope)
+    [InlineData(SitemapPolicy.All)]
+    [InlineData(SitemapPolicy.OnlyValid)]
+    public void WHEN_Value_is_valid_sitemap_WHILE_Including_valid_sitemaps_THEN_Deserialize_valid_sitemap(SitemapPolicy sitemapPolicy)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(
-            inclusionScope: inclusionScope
-        );
-
+        var options = new RobotsDeserializerOptions
+        {
+            SitemapPolicy = sitemapPolicy
+        }.ToImmutableOrDefault();
+        
         // Act
-        var sitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: string.Empty);
+        var sitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: string.Empty, options);
         
         // Assert
         Assert.IsType<ValidSitemap>(sitemap);
     }
     
     [Theory]
-    [InlineData(InclusionScope.InvalidOnly)]
-    public void WHEN_Value_is_valid_sitemap_WHILE_Excluding_valid_sitemaps_THEN_Return_null(InclusionScope inclusionScope)
+    [InlineData(SitemapPolicy.OnlyInvalid)]
+    public void WHEN_Value_is_valid_sitemap_WHILE_Excluding_valid_sitemaps_THEN_Return_null(SitemapPolicy sitemapPolicy)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(
-            inclusionScope: inclusionScope
-        );
+        var options = new RobotsDeserializerOptions
+        {
+            SitemapPolicy = sitemapPolicy
+        }.ToImmutableOrDefault();
 
         // Act
-        var sitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: string.Empty);
+        var sitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: string.Empty, options);
         
         // Assert
         Assert.Null(sitemap);
@@ -87,12 +89,10 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Value_is_set_WHILE_Deserializing_valid_sitemap_THEN_Set_value_on_valid_sitemap(string value)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         var expectedValue = value;
         
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty, _options);
         
         // Assert
         var validSitemap = Assert.IsType<ValidSitemap>(deserializedSitemap);
@@ -104,13 +104,11 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Value_is_set_WHILE_Deserializing_valid_sitemap_THEN_Set_rui_on_valid_sitemap()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         const string value = "https://www.example.com/sitemap.xml";
         var expectedUri = new Uri(value);
         
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty, _options);
         
         // Assert
         var validSitemap = Assert.IsType<ValidSitemap>(deserializedSitemap);
@@ -122,13 +120,11 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Value_is_null_WHILE_Deserializing_valid_sitemap_THEN_Throw_exception()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         const string? value = null;
         
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => 
-            sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty)
+            _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: value, comment: null, line: string.Empty, _options)
         );
 
         // Assert
@@ -145,12 +141,10 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Comment_is_set_WHILE_Deserializing_valid_sitemap_THEN_Set_comment_on_valid_sitemap(string comment)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         var expectedComment = comment;
 
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: comment, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: comment, line: string.Empty, _options);
         
         // Assert
         var validSitemap = Assert.IsType<ValidSitemap>(deserializedSitemap);
@@ -162,13 +156,11 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Comment_is_null_WHILE_Deserializing_valid_sitemap_THEN_Set_comment_on_valid_sitemap()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         const string? comment = null;
         const string? expectedComment = comment;
 
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: comment, line: string.Empty);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: comment, line: string.Empty, _options);
         
         // Assert
         var validSitemap = Assert.IsType<ValidSitemap>(deserializedSitemap);
@@ -183,12 +175,10 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Line_is_set_WHILE_Deserializing_valid_sitemap_THEN_Set_full_line_on_valid_sitemap(string line)
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         var expectedLine = line;
 
         // Act
-        var deserializedSitemap = sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: line);
+        var deserializedSitemap = _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: line, _options);
         
         // Assert
         var validSitemap = Assert.IsType<ValidSitemap>(deserializedSitemap);
@@ -200,13 +190,11 @@ public sealed class DeserializeValidSitemapTests
     public void WHEN_Line_is_null_WHILE_Deserializing_valid_sitemap_THEN_Throw_exception()
     {
         // Arrange
-        var sitemapLineDeserializer = new SitemapLineDeserializer(InclusionScope.ValidOnly);
-
         const string? line = null;
         
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => 
-            sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: line)
+            _sitemapLineDeserializer.Deserialize(directive: SitemapDirective, value: ValidSitemapValue, comment: null, line: line, _options)
         );
 
         // Assert


### PR DESCRIPTION
Options specified in RobotsDeserializerOptions are now mapped to an ImmutableRobotsDeserializationOptions instance as the first thing in RobotsDeserializer, before being passed on to the rest of the code. If no options are provided (null) as instance with default options are created before the mapping step.

Minor cleanup in RobotsDeserializerOptions: The properties IncludeSitemaps (bool) and SitemapsInclusionScope (enum) was been consolidated into the unified enum property SitemapPolicy. SitemapPolicy covers all of the same use cases as the two old properties.

Options are now passed into ILineDeserializer instance through the Deserialize method instead of the constructor. This has been done in preparation for custom line deserializer support. Passing the options in through the method instead of the constructor will give 3rd party developers access to the options.